### PR TITLE
Update diggy.sh

### DIFF
--- a/diggy.sh
+++ b/diggy.sh
@@ -80,7 +80,7 @@ extract () {
 }
 
 regxy () {
-    matches=$(grep -ProI "[\"'\`](https?://|/)[\w\.-/]+[\"'\`]")
+    matches=$(grep -ProI "[\"'\`](https?://|/)[\w\.-/]+[\"'\`]" $decom)
     for final in $matches
     do
         final=${final//$"\""/}


### PR DESCRIPTION
In current directory, diggy greps endpoints from all the files present. This made it accumulate endpoints from previous run results.